### PR TITLE
naming consistency/clarity within src/rail/estimation

### DIFF
--- a/src/rail/estimation/algos/minisom_som.py
+++ b/src/rail/estimation/algos/minisom_som.py
@@ -31,7 +31,7 @@ def _computemagcolordata(data, ref_column_name, column_names, colusage):
     return coldata.T
 
 
-class Inform_SimpleSOMSummarizer(CatInformer):
+class MiniSOMInformer(CatInformer):
     """Summarizer that uses a SOM to construct a weighted sum
     of spec-z objects in the same SOM cell as each photometric
     galaxy in order to estimate the overall N(z).  This is
@@ -73,7 +73,7 @@ class Inform_SimpleSOMSummarizer(CatInformer):
       pickle file containing the `minisom` SOM object that
     will be used by the estimation/summarization stage
     """
-    name = 'Inform_SimpleSOM'
+    name = 'MiniSOMInformer'
     config_options = CatInformer.config_options.copy()
     config_options.update(nondetect_val=SHARED_PARAMS,
                           mag_limits=SHARED_PARAMS,
@@ -130,7 +130,7 @@ class Inform_SimpleSOMSummarizer(CatInformer):
         self.add_data('model', self.model)
 
 
-class SimpleSOMSummarizer(SZPZSummarizer):
+class MiniSOMSummarizer(SZPZSummarizer):
     """Quick implementation of a SOM-based summarizer that
     constructs and N(z) estimate via a weighted sum of the
     empirical N(z) consisting of the normalized histogram
@@ -192,7 +192,7 @@ class SimpleSOMSummarizer(SZPZSummarizer):
     qp_ens: qp Ensemble
       ensemble of bootstrap realizations of the estimated N(z) for the input photometric data
     """
-    name = 'SimpleSOMSummarizer'
+    name = 'MiniSOMSummarizer'
     config_options = SZPZSummarizer.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,

--- a/src/rail/estimation/algos/somoclu_som.py
+++ b/src/rail/estimation/algos/somoclu_som.py
@@ -123,7 +123,7 @@ def plot_som(ax, som_map, grid_type='rectangular', colormap=cm.viridis, cbar_nam
     ax.axis('off')
 
 
-class Inform_somocluSOMSummarizer(CatInformer):
+class SOMocluInformer(CatInformer):
     """Summarizer that uses a SOM to construct a weighted sum
     of spec-z objects in the same SOM cell as each photometric
     galaxy in order to estimate the overall N(z).  This is
@@ -169,7 +169,7 @@ class Inform_somocluSOMSummarizer(CatInformer):
       pickle file containing the `somoclu` SOM object that
     will be used by the estimation/summarization stage
     """
-    name = 'Inform_SOMoclu'
+    name = 'SOMocluInformer'
     config_options = CatInformer.config_options.copy()
     config_options.update(nondetect_val=SHARED_PARAMS,
                           mag_limits=SHARED_PARAMS,
@@ -233,7 +233,7 @@ class Inform_somocluSOMSummarizer(CatInformer):
         self.add_data('model', self.model)
 
 
-class somocluSOMSummarizer(SZPZSummarizer):
+class SOMocluSummarizer(SZPZSummarizer):
     """Quick implementation of a SOM-based summarizer. It will
     group a pre-trained SOM into hierarchical clusters and assign
     a galaxy sample into SOM cells and clusters. Then it
@@ -298,7 +298,7 @@ class somocluSOMSummarizer(SZPZSummarizer):
     qp_ens: qp Ensemble
       ensemble of bootstrap realizations of the estimated N(z) for the input photometric data
     """
-    name = 'somocluSOMSummarizer'
+    name = 'SOMocluSummarizer'
     config_options = SZPZSummarizer.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,

--- a/src/rail/som/__init__.py
+++ b/src/rail/som/__init__.py
@@ -1,4 +1,4 @@
 from ._version import __version__
 
 from rail.estimation.algos.minisom_som import *
-from rail.estimation.algos.somocluSOM import *
+from rail.estimation.algos.somoclu_som import *

--- a/src/rail/som/__init__.py
+++ b/src/rail/som/__init__.py
@@ -1,4 +1,4 @@
 from ._version import __version__
 
-from rail.estimation.algos.simpleSOM import *
+from rail.estimation.algos.minisom_som import *
 from rail.estimation.algos.somocluSOM import *

--- a/tests/som/test_som_summarizers.py
+++ b/tests/som/test_som_summarizers.py
@@ -6,7 +6,7 @@ import qp
 from rail.core.data import TableHandle
 from rail.core.stage import RailStage
 from rail.core.utils import RAILDIR
-from rail.estimation.algos import simpleSOM
+from rail.estimation.algos import minisom_som
 
 testszdata = os.path.join(RAILDIR, "rail/examples_data/testdata/training_100gal.hdf5")
 testphotdata = os.path.join(RAILDIR, "rail/examples_data/testdata/validation_10gal.hdf5")
@@ -61,8 +61,8 @@ def one_algo(key, inform_class, summarizer_class, summary_kwargs):
 
 def test_SimpleSOM():
     summary_config_dict = {"m_dim": 21, "n_dim": 21, "column_usage": "colors"}
-    inform_class = simpleSOM.Inform_SimpleSOMSummarizer
-    summarizerclass = simpleSOM.SimpleSOMSummarizer
+    inform_class = minisom_som.MiniSOMInformer
+    summarizerclass = minisom_som.MiniSOMSummarizer
     _ = one_algo("SimpleSOM", inform_class, summarizerclass, summary_config_dict)
 
 
@@ -73,6 +73,6 @@ def test_SimpeSOM_with_mag_and_colors():
         "column_usage": "magandcolors",
         "objid_name": "id",
     }
-    inform_class = simpleSOM.Inform_SimpleSOMSummarizer
-    summarizerclass = simpleSOM.SimpleSOMSummarizer
+    inform_class = minisom_som.MiniSOMInformer
+    summarizerclass = minisom_som.MiniSOMSummarizer
     _ = one_algo("SimpleSOM_wmag", inform_class, summarizerclass, summary_config_dict)

--- a/tests/som/test_somoclu_summarizers.py
+++ b/tests/som/test_somoclu_summarizers.py
@@ -6,7 +6,7 @@ import qp
 from rail.core.data import TableHandle
 from rail.core.stage import RailStage
 from rail.core.utils import RAILDIR
-from rail.estimation.algos import somocluSOM
+from rail.estimation.algos import somoclu_som
 
 testszdata = os.path.join(RAILDIR, "rail/examples_data/testdata/training_100gal.hdf5")
 testphotdata = os.path.join(RAILDIR, "rail/examples_data/testdata/validation_10gal.hdf5")
@@ -61,8 +61,8 @@ def one_algo(key, inform_class, summarizer_class, summary_kwargs):
 
 def test_SomocluSOM():
     summary_config_dict = {"n_rows": 21, "n_columns": 21, "column_usage": "colors"}
-    inform_class = somocluSOM.Inform_somocluSOMSummarizer
-    summarizerclass = somocluSOM.somocluSOMSummarizer
+    inform_class = somoclu_som.SOMocluInformer
+    summarizerclass = somoclu_som.SOMocluSummarizer
     _ = one_algo("SOMomoclu", inform_class, summarizerclass, summary_config_dict)
 
 
@@ -73,6 +73,6 @@ def test_SomocluSOM_with_mag_and_colors():
         "column_usage": "magandcolors",
         "objid_name": "id",
     }
-    inform_class = somocluSOM.Inform_somocluSOMSummarizer
-    summarizerclass = somocluSOM.somocluSOMSummarizer
+    inform_class = somoclu_som.SOMocluInformer
+    summarizerclass = somoclu_som.SOMocluSummarizer
     _ = one_algo("SOMoclu_wmag", inform_class, summarizerclass, summary_config_dict)


### PR DESCRIPTION
## Change Description

This PR (and other concurrent PRs in the other repos) include renamings of modules and stages within `src/rail/estimation` for consistency and transparency to users as outlined in LSSTDESC/rail#37. (Expect a few more PRs to address the smaller set of necessary consistency/clarity changes outside `src/rail/estimation` using the same branch.) 

- [x] My PR includes a link to the issue that I am addressing

I request that multiple reviewers please do not hesitate to suggest changes as needed! The goals are consistency, clarity, and longevity, so if something looks unclear, inconsistent, or insufficiently flexible to accommodate future development, now is the time to make adjustments.

## Solution Description

The following changes were made across all the rail repos, along with updates to the contributing documentation (which should be propagated to the rail python project template so prompts regarding naming are included in future PR checklists).

```
files:
  delightPZ.py --> delight_hybrid.py
  GPz.py --> _gpz_util.py
  knnpz.py --> k_nearneigh.py
  naiveStack.py --> naive_stack.py
  NZDir.py --> nz_dir.py
  pointEstimateHist.py --> point_est_hist.py
  pzflow.py --> pzflow_nf.py
  randomPZ.py --> random_gauss.py
  simpleSOM.py --> minisom_som.py
  sklearn_nn.py --> skl_neurnet.py
  somocluSOM.py --> somoclu_som.py
  trainZ.py --> train_z.py
  varInference.py --> var_inf.py
classes:
  Inform_BPZ_lite --> BPZliteInformer
  BPZ_lite --> BPZliteEstimator
  Inform_CMNNPDF --> CMNNInformer
  CMNNPDF --> CMNNEstimator
  Inform_DelightPZ --> DelightInformer
  delightPZ --> DelightEstimator  
  Inform_GPz_v1 --> GPzInformer
  GPz_v1 --> GPzEstimator
  Inform_FZBoost --> FlexZBoostInformer
  FZBoost --> FlexZBoostEstimator
  Inform_KNearNeighPDF --> KNearNeighInformer
  KNearNeighPDF --> KNearNeighEstimator
  NaiveStack --> NaiveStackSummarizer
  NZDir --> NZDirSummarizer  
  Inform_NZDir --> NZDirInformer
  PointEstimateHist --> PointEstHistSummarizer
  Inform_PZFlowPDF --> PZFlowInformer
  PZFlowPDF --> PZFlowEstimator
  RandomPZ --> RandomGaussEstimator
  Inform_SimpleNN --> SklNeurNetInformer
  SimpleNN --> SklNeurNetEstimator
  Inform_SimpleSOMSummarizer --> MiniSOMInformer
  SimpleSOMSummarizer --> MiniSOMSummarizer
  Inform_somocluSOMSummarizer --> SOMocluInformer
  somocluSOMSummarizer --> SOMocluSummarizer
  Inform_trainZ --> TrainZInformer
  TrainZ --> TrainZEstimator
  VarInferenceStack --> VarInfStackSummarizer   
```

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [X] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

Given that we are still pre-v1, I have not explicitly included backward compatibility, but a block of `import X as Y` can be constructed from the above list of changes.

### Other Change Checklist
- [X] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have updated unit/End-to-End (E2E) test cases to cover any changes

I fixed some instances of outdated descriptions in the demo notebooks, but others require more substantial editing, e.g. when they describe code that has long since been removed from the demo in question or aspects of the API that have significantly changed since the descriptions were written. The demos require a thorough review before v1 that's out of scope for this series of PRs.