### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "scikit-learn",
     "minisom",
     "somoclu",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "scikit-learn",
     "minisom",
     "somoclu",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "scikit-learn",
     "minisom",
     "somoclu",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
     "scikit-learn",
     "minisom",
     "somoclu",

--- a/src/rail/estimation/algos/minisom_som.py
+++ b/src/rail/estimation/algos/minisom_som.py
@@ -92,7 +92,7 @@ class MiniSOMInformer(CatInformer):
     def __init__(self, args, **kwargs):
         """ Constructor:
         Do Informer specific initialization """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.model = None
 
     def run(self):
@@ -216,7 +216,7 @@ class MiniSOMSummarizer(SZPZSummarizer):
         self.zgrid = None
         self.model = None
         self.usecols = None
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.som = None
         self.column_usage = None
         self.ref_column_name = None

--- a/src/rail/estimation/algos/minisom_som.py
+++ b/src/rail/estimation/algos/minisom_som.py
@@ -89,10 +89,10 @@ class MiniSOMInformer(CatInformer):
                           som_learning_rate=Param(float, 0.5, msg="SOM learning rate"),
                           som_iterations=Param(int, 10_000, msg="number of iterations in SOM training"))
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor:
         Do Informer specific initialization """
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.model = None
 
     def run(self):
@@ -212,11 +212,11 @@ class MiniSOMSummarizer(SZPZSummarizer):
                ('cellid_output', TableHandle),
                ('uncovered_cell_file', TableHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         self.zgrid = None
         self.model = None
         self.usecols = None
-        SZPZSummarizer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.som = None
         self.column_usage = None
         self.ref_column_name = None

--- a/src/rail/estimation/algos/somoclu_som.py
+++ b/src/rail/estimation/algos/somoclu_som.py
@@ -204,7 +204,7 @@ class SOMocluInformer(CatInformer):
     def __init__(self, args, **kwargs):
         """ Constructor:
         Do Informer specific initialization """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.model = None
 
     def run(self):
@@ -333,7 +333,7 @@ class SOMocluSummarizer(SZPZSummarizer):
         self.zgrid = None
         self.model = None
         self.usecols = None
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.som = None
         self.column_usage = None
         self.ref_column_name = None

--- a/src/rail/estimation/algos/somoclu_som.py
+++ b/src/rail/estimation/algos/somoclu_som.py
@@ -201,10 +201,10 @@ class SOMocluInformer(CatInformer):
                                           + "Default: 1.5"),
                           som_learning_rate=Param(float, 0.5, msg="Initial SOM learning rate (scale0 param in Somoclu)"))
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor:
         Do Informer specific initialization """
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.model = None
 
     def run(self):
@@ -329,11 +329,11 @@ class SOMocluSummarizer(SZPZSummarizer):
                ('cellid_output', Hdf5Handle),
                ('uncovered_cluster_file', TableHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         self.zgrid = None
         self.model = None
         self.usecols = None
-        SZPZSummarizer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.som = None
         self.column_usage = None
         self.ref_column_name = None


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.