### PR TITLE
#17 add SOM-based spec-z selection degrader

### DIFF
--- a/examples/demo_SOMPZdegrader.ipynb
+++ b/examples/demo_SOMPZdegrader.ipynb
@@ -1,0 +1,490 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "963ec5d4-c617-41fc-8cb7-7b74d9f45195",
+   "metadata": {},
+   "source": [
+    "# SOMSpeczDegrader Demo\n",
+    "\n",
+    "Author: Sam Schmidt\n",
+    "\n",
+    "Last successfully run: December 11, 2024\n",
+    "\n",
+    "This is a short demo of the use of the SOM-based degrader `SOMSpeczDegrader` that is designed to select a subset of an input galaxy sample via SOM classification such that they match the properties of a reference sample, e.g. to make mock spectroscopic selections for a training set.  \n",
+    "\n",
+    "The code works by training a SOM using the (presumably larger) input dataset, then classifying each galaxy from both the input dataset and the reference dataset to find the best SOM cell.  It then loops over all occupied SOM cells, counts the number of reference galaxies in a cell, and selects the same number of input objects in that cell to include in the degraded sample (if there are more objects in the reference sample than are available to pick from in the reference sample, then it simply takes all available objects, which does mean that you can end up with some incompleteness if areas of your parameter space have more objects in the reference sample than the input).  This should naturally force the chosen subsample to match (as much as possible given SOM cell classification given the input parameters) the properties of the reference sample.\n",
+    "\n",
+    "Note that, like other RAIL degraders, this degrader expects the input to be in a Pandas dataframe.\n",
+    "\n",
+    "We will demonstrate below, starting with some necessary imports:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdf21773-a138-4f74-b3f0-f171433f4359",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import os\n",
+    "import matplotlib.pyplot as plt\n",
+    "import tables_io"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88c11713-6302-4536-897d-5266a2abf9f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rail.creation.degraders.specz_som import SOMSpeczDegrader\n",
+    "from rail.utils.path_utils import find_rail_file\n",
+    "from rail.core.data import TableHandle, PqHandle\n",
+    "from rail.core.stage import RailStage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20885821-6835-4126-8f2d-f9fedbc3b8cd",
+   "metadata": {},
+   "source": [
+    "First, let's set up the RAIL DataStore, which is explained in other RAIL demo notebooks, as our interface to the data.  We will read in two files, one for reference (e.g. a specz sample that we would wish to model), and an input dataset.  Because the samples that are included with RAIL are both representative, we will first make a few cuts to mimic incompleteness before adding to the datastore.\n",
+    "\n",
+    "\n",
+    "**Note:** The SOMSpeczDegrader stage requires a reference/spectroscopic set, and the stage expects that stage to be labeled as \"spec_data\" in the DataStore!  So, once we make a few cuts to our example file, we will specify the name in the datastore as \"spec_data\".  Later in the notebook we will have to set a different name in the `aliases` for a second instance of the stage if we want to use a file with a different label as the reference/specz file (more on that below):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1325a9d4-e411-4bb4-b879-513243cc0dfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DS = RailStage.data_store\n",
+    "DS.__class__.allow_overwrite = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d202f9d-d488-4865-b072-52a3ad5eb19b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainfile = find_rail_file('examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testfile = find_rail_file('examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
+    "testhdf5 = tables_io.read(testfile)['photometry']\n",
+    "trainhdf5 = tables_io.read(trainfile)['photometry']\n",
+    "# convert the data to pandas dataframe\n",
+    "testpq = tables_io.convert(testhdf5, tables_io.types.PD_DATAFRAME)\n",
+    "trainpq = tables_io.convert(trainhdf5, tables_io.types.PD_DATAFRAME)\n",
+    "test_data = DS.add_data(\"input\",testpq, PqHandle)\n",
+    "\n",
+    "# make a few cuts to the \"training\" data to simulate some incompleteness so that the distributions do not match\n",
+    "# we'll cut all galaxies with redshift > 1.5 and mag_i_lsst > 24.4 and g-r color > 1.0\n",
+    "mask = np.logical_and(trainpq['redshift'] < 1.5,\n",
+    "                      np.logical_and(trainpq['mag_i_lsst'] < 24.4, \n",
+    "                                     trainpq['mag_g_lsst'] - trainpq['mag_r_lsst'] < 1.0))\n",
+    "cutpq = trainpq[mask]\n",
+    "\n",
+    "ref_data = DS.add_data(\"spec_data\", cutpq, PqHandle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b07ea95b-f1af-461e-b474-b9d203eff071",
+   "metadata": {},
+   "source": [
+    "Let's plot our two samples in redshift and color to compare:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05f11d2b-b040-453a-8e85-91e4d37511b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8,5))\n",
+    "zbins = np.linspace(-.01, 3.01, 51)\n",
+    "plt.hist(ref_data()['redshift'], bins=zbins, alpha=0.5, color='k', label=\"specz data\");\n",
+    "plt.hist(test_data()['redshift'], bins=zbins, alpha=0.5, color='orange', label=\"input data\");\n",
+    "plt.legend(loc='upper right', fontsize=12)\n",
+    "plt.xlabel(\"redshift\", fontsize=14)\n",
+    "plt.ylabel(\"Number\", fontsize=14);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7033c67-f89c-4b67-b09b-d2d8559faaaa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(2, 1, figsize=(7,10))\n",
+    "axs[0].scatter(test_data()['mag_i_lsst'], test_data()['mag_g_lsst'] - test_data()['mag_r_lsst'], \n",
+    "            s=1, label='input data', alpha=0.4, color='orange')\n",
+    "axs[0].scatter(ref_data()['mag_i_lsst'], ref_data()['mag_g_lsst'] - ref_data()['mag_r_lsst'], \n",
+    "            s=4, label='specz data', alpha=0.4, color='k')\n",
+    "axs[0].legend(loc='upper left', fontsize=12)\n",
+    "axs[0].set_xlabel(\"i-band magnitude\", fontsize=14)\n",
+    "axs[0].set_ylabel(\"g - r\", fontsize=14);\n",
+    "\n",
+    "\n",
+    "axs[1].scatter(test_data()['mag_g_lsst'] - test_data()['mag_r_lsst'], \n",
+    "               test_data()['mag_r_lsst'] - test_data()['mag_i_lsst'], \n",
+    "            s=1, label='input data', alpha=0.4, color='orange')\n",
+    "axs[1].scatter(ref_data()['mag_g_lsst'] - ref_data()['mag_r_lsst'],\n",
+    "               ref_data()['mag_r_lsst'] - ref_data()['mag_i_lsst'], \n",
+    "            s=4, label='specz data', alpha=0.4, color='k')\n",
+    "axs[1].legend(loc='upper right', fontsize=12)\n",
+    "axs[1].set_xlabel(\"g - r\", fontsize=14)\n",
+    "axs[1].set_ylabel(\"r - i\", fontsize=14);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e94896ea-978c-48cb-a92b-a2e293b3d3bc",
+   "metadata": {},
+   "source": [
+    "We can see that, given our cuts, our \"specz\" data is no longer representaive of the input sample.  Now, let's set up our degrader to try to select a subset of galaxies that matches the number and distribution of the specz sample.  We'll start by setting up the `SOMSpeczDegrader` stage.  As input, the stage takes in multiple config parameters, these are:\n",
+    "\n",
+    "- noncolor_cols: a list of column names in the files that will be used directly in training the SOM\n",
+    "\n",
+    "- color_cols: a list of column names in the files, these will be taken in order and differenced to make, e.g. colors.  So, if you want to include u-g, g-r, and r-i as inputs to the SOM, you would specify ['u', 'g', 'r', 'i'] as the `color_cols` values, and these will be differenced before inclusion in the SOM.\n",
+    "\n",
+    " - nondetect_val: if this value is present in either `noncolor_cols` or `color_cols` columns as a value, it will be replaced with the corresponding \"nondetection value\" in `noncolor_nondet` and`color_nondet` respectively.\n",
+    "                          \n",
+    "- noncolor_nondet: the list of nondetect values that a non-detection in `noncolor_cols` should be replaced with\n",
+    "\n",
+    "- color_nondet: the list of nondetect values that a non-detection in `color_cols` should be replaced with\n",
+    "                          \n",
+    "- som_size: a tuple,  e.g. (32, 32), that specifies the shape of the SOM.  (32, 32) is the default.\n",
+    "\n",
+    "\n",
+    "Let's set up our inputs.  As an example, let's train our SOM using i-band magnitude, redshift, and the colors u-g, g-r, r-i, i-z, and z-y.  To do this, we will specify `noncolor_cols` of 'mag_i_lsst' and 'redshift', and color_cols with all six magnitudes.  The code will difference the six magnitudes, producing the desired five colors.  Thus, our SOM inputs will be trained on seven inputs: `mag_i_lsst`, `redshift`, `u-g`, `g-r`, `r-i`, `i-z`, and `z-y`.  Note that we have explicitly included redshift.  This is possible because both our specz sample and our simulated input sample have true redshift available.  In real datasets where specz is not available, we would not be able to include redshift, and results will likely not match as well, particularly for the redshift distribution.\n",
+    "\n",
+    "We also need to specify the magnitude and color limits, we'll use the 1 sigma i-band 10 year limit for i-band and just put -1.0 for redshift.  For colors we'll just put 0.0 for all colors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "840c89b8-c850-422a-a5f3-e98f527137f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bands = ['u', 'g', 'r', 'i', 'z', 'y']\n",
+    "noncol_cols = ['mag_i_lsst', 'redshift']\n",
+    "col_cols = []\n",
+    "for band in bands:\n",
+    "    col_cols.append(f\"mag_{band}_lsst\")\n",
+    "\n",
+    "noncol_nondet = [28.62, -1.0]\n",
+    "col_nondet = np.zeros(5, dtype=float)\n",
+    "\n",
+    "som_dict = dict(color_cols=col_cols,\n",
+    "                noncolor_cols=noncol_cols,\n",
+    "                nondetect_val=99.0,\n",
+    "                noncolor_nondet=noncol_nondet,\n",
+    "                color_nondet=col_nondet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cb2e78a-6864-4da5-9387-40a4dda531e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "som_degrade = SOMSpeczDegrader.make_stage(name=\"som_degrader\", output=\"specz_mock_sample.pq\", **som_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eef9045c-7146-4e07-8d66-1495f407c590",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trimdf = som_degrade(test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f99189ba-abfd-4850-832e-f0ac0016966b",
+   "metadata": {},
+   "source": [
+    "let's plot the redshift histogram and mag vs color plot to see how well our selection matches the reference set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fac189f-2f2b-4287-a09a-4dbe16dc213f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(3,1, figsize=(8,18))\n",
+    "xbins = np.linspace(-.005, 3.005,52)\n",
+    "axs[0].hist(test_data()['redshift'], bins=xbins, alpha=0.15, color='orange', label='input sample');\n",
+    "axs[0].hist(ref_data()['redshift'], bins=xbins, alpha=0.5, color='k', label='specz sample');\n",
+    "axs[0].hist(trimdf()['redshift'], bins=xbins, alpha=0.15, color='r', label='degraded sample')\n",
+    "axs[0].set_xlabel('redshift', fontsize=14)\n",
+    "axs[0].legend(loc='upper right', fontsize=12)\n",
+    "axs[0].set_ylabel('number', fontsize=14);\n",
+    "\n",
+    "axs[1].scatter(test_data()['mag_i_lsst'], test_data()['mag_g_lsst'] - test_data()['mag_r_lsst'], \n",
+    "            s=2, label='input data', alpha=0.4, color='orange')\n",
+    "axs[1].scatter(ref_data()['mag_i_lsst'], ref_data()['mag_g_lsst'] - ref_data()['mag_r_lsst'], \n",
+    "            s=4, label='specz data', alpha=0.4, color='k')\n",
+    "axs[1].scatter(trimdf()['mag_i_lsst'], trimdf()['mag_g_lsst'] - trimdf()['mag_r_lsst'], \n",
+    "            s=4, label='degraded data', alpha=0.4, color='r')\n",
+    "axs[1].legend(loc='upper left', fontsize=12)\n",
+    "axs[1].set_ylim(-1,3.5);\n",
+    "axs[1].set_xlabel(\"i-band mag\", fontsize=14)\n",
+    "axs[1].set_ylabel(\"g - r\", fontsize=14)\n",
+    "\n",
+    "axs[2].scatter(test_data()['mag_g_lsst'] - test_data()['mag_r_lsst'], \n",
+    "               test_data()['mag_r_lsst'] - test_data()['mag_i_lsst'], \n",
+    "            s=2, label='input data', alpha=0.4, color='orange')\n",
+    "axs[2].scatter(ref_data()['mag_g_lsst'] - ref_data()['mag_r_lsst'],\n",
+    "               ref_data()['mag_r_lsst'] - ref_data()['mag_i_lsst'], \n",
+    "            s=4, label='specz data', alpha=0.4, color='k')\n",
+    "axs[2].scatter(trimdf()['mag_g_lsst'] - trimdf()['mag_r_lsst'],\n",
+    "               trimdf()['mag_r_lsst'] - trimdf()['mag_i_lsst'], \n",
+    "            s=4, label='degraded data', alpha=0.3, color='r')\n",
+    "axs[2].legend(loc='upper right', fontsize=12)\n",
+    "axs[2].set_xlabel(\"g - r\", fontsize=14)\n",
+    "axs[2].set_ylabel(\"r - i\", fontsize=14)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8843a3ce-eac8-4155-8a16-130501f138b5",
+   "metadata": {},
+   "source": [
+    "The redshift distribution of our degraded sample matches very well with the reference data, the magnitude vs color distribution is not as clean; however, this is very likely due to the small number of objects used to train the SOM, and performance and matchup should improve with larger samples.  Below we will download a slightly larger data samples, and we can (optionally) test how well the results agree when more data is available.  \n",
+    "\n",
+    "\n",
+    "**Note:**\n",
+    "The files are rather large, so you will need to uncomment the lines below in order to download the files and have the second half of this notebook run.  Let's grab some data from the Roman-DESC sims, we'll grab a tar file with two files, one with 37,500 galaxies, and one with 75,000 galaxies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45a97a88-e994-47a1-b975-58684927abb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_file = \"./romandesc_specdeep.tar\"\n",
+    "\n",
+    "#UNCOMMENT THESE LINES TO GRAB THE LARGER DATA FILES!\n",
+    "\n",
+    "#if not os.path.exists(training_file):\n",
+    "#  os.system('curl -O https://portal.nersc.gov/cfs/lsst/PZ/romandesc_specdeep.tar')\n",
+    "#!tar -xvf romandesc_specdeep.tar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01ffce9b-5018-4ef3-b0ee-efbe6fe8b105",
+   "metadata": {},
+   "source": [
+    "We will read in the two files, make similar cuts to the mock \"spec\" file as we did in the example above, and then add the files to the datastore"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84605d30-65b9-468e-b244-b48712c374b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rdspecfile = \"./romandesc_spec_data_37k.hdf5\"\n",
+    "rdtestfile = \"./romandesc_deep_data_75k.hdf5\"\n",
+    "\n",
+    "rdtest = tables_io.read(rdtestfile)\n",
+    "rdtestpq = tables_io.convert(rdtest, tables_io.types.PD_DATAFRAME)\n",
+    "big_test_data = DS.add_data(\"big_input\", rdtestpq, PqHandle)\n",
+    "\n",
+    "\n",
+    "rdspec = tables_io.read(rdspecfile)\n",
+    "rdspecpq = tables_io.convert(rdspec, tables_io.types.PD_DATAFRAME)\n",
+    "\n",
+    "mask = np.logical_and(rdspecpq['redshift'] < 1.5,\n",
+    "                      np.logical_and(rdspecpq['i'] < 24.4, \n",
+    "                                     rdspecpq['g'] - rdspecpq['r'] < 1.0))\n",
+    "rdspecpqcut = rdspecpq[mask]\n",
+    "big_spec_data = DS.add_data(\"big_spec\", rdspecpqcut, PqHandle)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aad8ec8e-e1f8-4497-be13-f8112186d831",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the columns available, this file should contain both the magnitudes and colors for the Roman-DESC sims:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57e1e907-9bbb-4cb4-ae58-1f5296c5786a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "big_spec_data().head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "706609b1-8295-4521-af0a-60fa4a2d60d6",
+   "metadata": {},
+   "source": [
+    "As in the first example, we will just use i, redshift, and the five colors to build the SOM.  Because the colors are already present we can just add them directly to the non-color columns. Let's set things up appropriately:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26cf7979-1d15-4d93-9c1d-1684301c6dfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noncol_cols = ['i', 'redshift', 'ug', 'gr', 'ri', 'iz', 'zy']\n",
+    "col_cols = []\n",
+    "\n",
+    "noncol_nondet = [28.62, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n",
+    "col_nondet = []\n",
+    "\n",
+    "som_dict = dict(color_cols=col_cols,\n",
+    "                noncolor_cols=noncol_cols,\n",
+    "                nondetect_val=99.0,\n",
+    "                noncolor_nondet=noncol_nondet,\n",
+    "                color_nondet=col_nondet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ca62808-f505-4a3e-a9f2-640ad31ac5db",
+   "metadata": {},
+   "source": [
+    "**Note:** as mentioned earlier in this demo, the `SOMSpeczDegrader` stage expects the reference/spectroscopic data file to be labeled as \"spec_data\" in the DataStore.  As we already loaded the previous example data with that name, we'll need to tell this second copy of the `SOMSpeczDegrader` stage that we will be using a dataset with a different label.  We do this by setting the new label in a dictionary fed in as `aliases` to the stage.  We added the new reference/specz file with the label \"big_spec\", so we can simply add `aliases=dict(spec_data=\"big_spec\")` to let the stage know which file to use as the reference/spec data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b5e73ac-ee59-416d-8dc3-6ec6166944e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# note that \n",
+    "roman_som_degrade = SOMSpeczDegrader.make_stage(name=\"roman_som_degrader\", \n",
+    "                                                output=\"roman_specz_mock_sample.pq\", \n",
+    "                                                aliases = dict(spec_data=\"big_spec\"),\n",
+    "                                                **som_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aeb05326-e355-4f12-a853-25060d23813d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "roman_trim = roman_som_degrade(big_test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75402f9f-21db-49e7-a14d-b0d06a84b704",
+   "metadata": {},
+   "source": [
+    "Let's make the same plots as above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5e7b0d5-7d82-4cf7-9375-aabc9d864121",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(3,1, figsize=(8,18))\n",
+    "xbins = np.linspace(-.005, 3.005,52)\n",
+    "axs[0].hist(big_test_data()['redshift'], bins=xbins, alpha=0.15, color='orange', label='input sample');\n",
+    "axs[0].hist(big_spec_data()['redshift'], bins=xbins, alpha=0.5, color='k', label='specz sample');\n",
+    "axs[0].hist(roman_trim()['redshift'], bins=xbins, alpha=0.15, color='r', label='degraded sample')\n",
+    "axs[0].set_xlabel('redshift', fontsize=14)\n",
+    "axs[0].legend(loc='upper right', fontsize=12)\n",
+    "axs[0].set_ylabel('number', fontsize=14);\n",
+    "\n",
+    "axs[1].scatter(big_test_data()['i'], big_test_data()['gr'], \n",
+    "            s=2, label='input data', alpha=0.4, color='orange')\n",
+    "axs[1].scatter(big_spec_data()['i'], big_spec_data()['gr'], \n",
+    "            s=4, label='specz data', alpha=0.4, color='k')\n",
+    "axs[1].scatter(roman_trim()['i'], roman_trim()['gr'], \n",
+    "            s=4, label='degraded data', alpha=0.4, color='r')\n",
+    "axs[1].legend(loc='upper left', fontsize=12)\n",
+    "axs[1].set_ylim(-.5,2.2);\n",
+    "\n",
+    "axs[2].scatter(big_test_data()['gr'], \n",
+    "               big_test_data()['ri'], \n",
+    "               s=2, label='input data', alpha=0.4, color='orange')\n",
+    "axs[2].scatter(big_spec_data()['gr'],\n",
+    "               big_spec_data()['ri'],\n",
+    "               s=4, label='specz data', alpha=0.4, color='k')\n",
+    "axs[2].scatter(roman_trim()['gr'],\n",
+    "               roman_trim()['ri'],\n",
+    "               s=4, label='degraded data', alpha=0.3, color='r')\n",
+    "axs[2].legend(loc='upper right', fontsize=12)\n",
+    "axs[2].set_xlabel(\"g - r\", fontsize=14)\n",
+    "axs[2].set_ylabel(\"r - i\", fontsize=14)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c42ef91-1de7-4466-b0a9-e4ba31f8d117",
+   "metadata": {},
+   "source": [
+    "We again see good agreement on the redshift distribution, and good but not perfect agreement on magnitude and color distributions.  So, it appears that our mock specz selection algorithm is working as expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b1871e6-ce51-4ebf-8ffb-a61bbbcc6a6e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/demo_SOMPZdegrader.ipynb
+++ b/examples/demo_SOMPZdegrader.ipynb
@@ -229,8 +229,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axs = plt.subplots(3,1, figsize=(8,18))\n",
+    "fig, axs = plt.subplots(4,1, figsize=(8,24))\n",
     "xbins = np.linspace(-.005, 3.005,52)\n",
+    "magbins = np.linspace(14, 25.5, 52)\n",
     "axs[0].hist(test_data()['redshift'], bins=xbins, alpha=0.15, color='orange', label='input sample');\n",
     "axs[0].hist(ref_data()['redshift'], bins=xbins, alpha=0.5, color='k', label='specz sample');\n",
     "axs[0].hist(trimdf()['redshift'], bins=xbins, alpha=0.15, color='r', label='degraded sample')\n",
@@ -260,7 +261,14 @@
     "            s=4, label='degraded data', alpha=0.3, color='r')\n",
     "axs[2].legend(loc='upper right', fontsize=12)\n",
     "axs[2].set_xlabel(\"g - r\", fontsize=14)\n",
-    "axs[2].set_ylabel(\"r - i\", fontsize=14)"
+    "axs[2].set_ylabel(\"r - i\", fontsize=14)\n",
+    "\n",
+    "axs[3].hist(test_data()['mag_i_lsst'], bins=magbins, alpha=0.15, color='orange', label='input sample');\n",
+    "axs[3].hist(ref_data()['mag_i_lsst'], bins=magbins, alpha=0.5, color='k', label='specz sample');\n",
+    "axs[3].hist(trimdf()['mag_i_lsst'], bins=magbins, alpha=0.15, color='r', label='degraded sample')\n",
+    "axs[3].set_xlabel('i-band magnitude', fontsize=14)\n",
+    "axs[3].legend(loc='upper left', fontsize=12)\n",
+    "axs[3].set_ylabel('number', fontsize=14);\n"
    ]
   },
   {
@@ -417,8 +425,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axs = plt.subplots(3,1, figsize=(8,18))\n",
+    "fig, axs = plt.subplots(4,1, figsize=(8,24))\n",
     "xbins = np.linspace(-.005, 3.005,52)\n",
+    "magbins = np.linspace(14, 25.5, 52)\n",
     "axs[0].hist(big_test_data()['redshift'], bins=xbins, alpha=0.15, color='orange', label='input sample');\n",
     "axs[0].hist(big_spec_data()['redshift'], bins=xbins, alpha=0.5, color='k', label='specz sample');\n",
     "axs[0].hist(roman_trim()['redshift'], bins=xbins, alpha=0.15, color='r', label='degraded sample')\n",
@@ -446,7 +455,14 @@
     "               s=4, label='degraded data', alpha=0.3, color='r')\n",
     "axs[2].legend(loc='upper right', fontsize=12)\n",
     "axs[2].set_xlabel(\"g - r\", fontsize=14)\n",
-    "axs[2].set_ylabel(\"r - i\", fontsize=14)"
+    "axs[2].set_ylabel(\"r - i\", fontsize=14)\n",
+    "\n",
+    "axs[3].hist(big_test_data()['i'], bins=magbins, alpha=0.15, color='orange', label='input sample');\n",
+    "axs[3].hist(big_spec_data()['i'], bins=magbins, alpha=0.5, color='k', label='specz sample');\n",
+    "axs[3].hist(roman_trim()['i'], bins=magbins, alpha=0.15, color='r', label='degraded sample')\n",
+    "axs[3].set_xlabel('i-band magnitude', fontsize=14)\n",
+    "axs[3].legend(loc='upper left', fontsize=12)\n",
+    "axs[3].set_ylabel('number', fontsize=14);"
    ]
   },
   {
@@ -454,7 +470,7 @@
    "id": "1c42ef91-1de7-4466-b0a9-e4ba31f8d117",
    "metadata": {},
    "source": [
-    "We again see good agreement on the redshift distribution, and good but not perfect agreement on magnitude and color distributions.  So, it appears that our mock specz selection algorithm is working as expected."
+    "We again see good agreement on the redshift and i-band magnitude distributions, and good but not perfect agreement on magnitude-color and color-color distributions.  So, it appears that our mock specz selection algorithm is working as expected."
    ]
   },
   {

--- a/src/rail/creation/degraders/specz_som.py
+++ b/src/rail/creation/degraders/specz_som.py
@@ -1,0 +1,111 @@
+"""Selector that emulate specz selection with SOM"""
+
+# import os
+import numpy as np
+# import pandas as pd
+# import pickle
+# import tables_io
+from rail.creation.selector import Selector
+# from rail.estimation.algos.somoclu_som import SOMocluInformer
+from somoclu import Somoclu
+from rail.core.common_params import SHARED_PARAMS
+from rail.core.data import TableHandle
+from rail.estimation.algos.somoclu_som import get_bmus
+from ceci.config import StageParameter as Param
+
+default_noncolor_cols = ["i", "redshift"]
+default_noncolor_nondet = [28.62, -1.0]
+default_color_cols = ['u', 'g', 'r', 'i', 'z', 'y']
+default_colorcol_nondet = [27.79, 29.04, 29.06, 28.62, 27.98, 27.05]
+
+
+class SOMSpeczDegrader(Selector):
+    """Class that creates a specz sample by training
+    a SOM on data with spec-z, classifying all galaxies
+    from a larger sample via the SOM, then selecting the
+    same number of galaxies in each SOM cell as there
+    are in the specz sample.  If fewer galaxies are
+    available in the large sample for a cell, it just
+    takes as many as possible, so you can still mismatch
+    the distribution numbers"""
+
+    name = "SOMSpeczDegrader"
+    config_options = Selector.config_options.copy()
+    config_options.update(nondetect_val=SHARED_PARAMS,
+                          noncolor_cols=Param(list, default_noncolor_cols, msg="data columns used for SOM, can be a single band if"
+                                              "you will also be using colordata in 'color_cols', or can be as many as you want"),
+                          noncolor_nondet=Param(list, default_noncolor_nondet, msg="list of nondetect replacement values for the non-color cols"),
+                          color_cols=Param(list, default_color_cols, msg="columns that will be differenced to make"
+                                           " colors.  This will be done in order, so put in increasing WL order"),
+                          color_nondet=Param(list, default_colorcol_nondet, msg="list of nondetect replacement vals for color columns"),
+                          som_size=Param(tuple, (32, 32), msg="tuple containing the size (x, y) of the SOM"),
+                          n_epochs=Param(int, 10, msg="number of training epochs."))
+
+    inputs = [('spec_data', TableHandle),
+              ('input', TableHandle),
+              ]
+
+    def __init__(self, args, **kwargs):
+        super().__init__(args, **kwargs)
+        # if self.config.redshift_cut < 0:
+        #     raise ValueError("redshift cut must be positive")
+
+    def make_data_selection(self, df):
+        """make the data to train the som or input to som"""
+        usecols = self.config.noncolor_cols.copy()
+        colcols = self.config.color_cols
+        ncol = len(self.config.color_cols)
+        for i in range(ncol - 1):
+            tmpname = f"{colcols[i]}" + "min" + f"{colcols[i+1]}"
+            usecols.append(tmpname)
+            df[tmpname] = df[colcols[i]] - df[colcols[i + 1]]
+        # NEED TO SELECT JUST USED ROWS AND OUTPUT TO NUMPY
+        subdf = df[usecols].to_numpy()
+
+        return subdf
+
+    def _select(self):
+        """code to do the main SOM-based selection"""
+        spec_data = self.get_data('spec_data')
+        deep_data = self.get_data('input')
+        # do some checks on whether data is set up properly and remove non-detects
+        check_vals = self.config.noncolor_cols + self.config.color_cols
+        check_lims = self.config.noncolor_nondet + self.config.color_nondet
+        for data in (spec_data, deep_data):
+            print("doing checks")
+            for val, lim in zip(check_vals, check_lims):
+                if val not in data.keys():  # pragma: no cover
+                    raise KeyError(f"required key {val} not present in input data file!")
+                if np.isnan(self.config.nondetect_val):  # pragma: no cover
+                    mask = np.isnan(data[val])
+                else:
+                    mask = np.logical_or(np.isinf(data[val]), np.isclose(data[val], self.config.nondetect_val))
+                # data[val][mask] = lim
+                data.loc[mask, val] = lim
+
+        specsomdata = self.make_data_selection(spec_data)
+        photsomdata = self.make_data_selection(deep_data)
+
+        SOM = Somoclu(self.config.som_size[0], self.config.som_size[1],
+                      gridtype='rectangular', compactsupport=False,
+                      maptype='planar', initialization='pca')
+
+        SOM.train(photsomdata, epochs=self.config.n_epochs,)
+
+        phot_bmu_coords = get_bmus(SOM, photsomdata).T
+        spec_bmu_coords = get_bmus(SOM, specsomdata).T
+
+        total_mask = np.zeros(len(deep_data), dtype=bool)
+
+        for i in range(self.config.som_size[0]):
+            for j in range(self.config.som_size[1]):
+                subset = np.logical_and(phot_bmu_coords[0] == i, phot_bmu_coords[1] == j)
+                subsetidx = np.where(subset)[0]
+                lengal = np.sum(subset)
+                howmany = np.sum(np.logical_and(spec_bmu_coords[0] == i, spec_bmu_coords[1] == j))
+                if howmany > lengal:
+                    howmany = lengal
+                perm = np.random.permutation(lengal)
+                total_mask[subsetidx[perm][:howmany]] = True
+
+        return total_mask

--- a/src/rail/creation/degraders/specz_som.py
+++ b/src/rail/creation/degraders/specz_som.py
@@ -120,7 +120,7 @@ class SOMSpeczDegrader(Selector):
                 subsetidx = np.where(subset)[0]
                 lengal = np.sum(subset)
                 howmany = np.sum(np.logical_and(spec_bmu_coords[0] == i, spec_bmu_coords[1] == j))
-                if howmany > lengal:
+                if howmany > lengal:  # pragma: no cover
                     howmany = lengal
                 perm = np.random.permutation(lengal)
                 total_mask[subsetidx[perm][:howmany]] = True

--- a/src/rail/som/__init__.py
+++ b/src/rail/som/__init__.py
@@ -2,3 +2,4 @@ from ._version import __version__
 
 from rail.estimation.algos.minisom_som import *
 from rail.estimation.algos.somoclu_som import *
+from rail.creation.degraders.specz_som import *

--- a/tests/som/test_som_speczdegrader.py
+++ b/tests/som/test_som_speczdegrader.py
@@ -1,0 +1,52 @@
+import os
+import numpy as np
+import pandas as pd
+import pytest
+from rail.core.stage import RailStage
+from rail.core.data import DATA_STORE, PqHandle
+from rail.creation.degraders.specz_som import SOMSpeczDegrader
+
+def test_SOMSpeczDegrader():
+    """test of the specz subset degrader"""
+    nspec = 1000
+    ninput = 10000
+    columns = ['redshift', 'u', 'g', 'r', 'i', 'z', 'y']
+    specdict = {}
+    inputdict = {}
+    rng = np.random.default_rng(1138)
+    for ii, col in enumerate(columns):
+        if ii == 0:
+            # numbers from 0 to 3
+            specdict[col] = rng.random(nspec) * 3.0
+            inputdict[col] = rng.random(ninput) * 3.0
+        else:
+            # numbers from 14 to 26
+            specdict[col] = rng.random(nspec) * 12.0 + 14.0
+            inputdict[col] = rng.random(ninput) * 12.0 + 14.0
+    specdf = pd.DataFrame(specdict)
+    inputdf = pd.DataFrame(inputdict)
+
+    DS = RailStage.data_store
+    DS.__class__.allow_overwrite = True
+    spec_data = DS.add_data("spec_data", specdf, PqHandle)
+    input_data = DS.add_data("input_data", inputdf, PqHandle)
+
+
+    noncol_cols = ['i', 'redshift']
+    col_cols = ['u', 'g', 'r', 'i', 'z', 'y']
+    
+    noncol_nondet = [28.62, -1.0 ]
+    col_nondet = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+    som_dict = dict(color_cols=col_cols,
+                    noncolor_cols=noncol_cols,
+                    nondetect_val=99.0,
+                    noncolor_nondet=noncol_nondet,
+                    color_nondet=col_nondet)
+
+    som_degrade = SOMSpeczDegrader.make_stage(name="roman_som_degrader", 
+                                              output="test_degraded_som.pq", 
+                                              **som_dict)
+    cutdf = som_degrade(input_data)
+    for col in columns:
+        assert col in cutdf().keys()


### PR DESCRIPTION
Addresses #17, I added a spectroscopic degrader that trains a som based on input columns in a big test file, ingests a smaller reference file, classifies both sets into best SOM cells, then iterates through all SOM cells and tries to match the number of reference objects with a random selection of input objects for that cell, which should naturally mimic the properties of the reference data.  

I included an example notebook, and I just ran the degrader on 6 million Roman-DESC objects and the 430,000 HSC galaxies, and results look good, so I think everything is working.

The biggest issue is that I'm bad at naming things, so whoever reviews should make any suggestions on config parameter names e.g. `noncolor_cols`, `noncolor_nondet`, etc...

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
