### PR TITLE
Change name of SOM spec degrader #19

### DIFF
--- a/examples/demo_SOMSpecSelector.ipynb
+++ b/examples/demo_SOMSpecSelector.ipynb
@@ -5,13 +5,13 @@
    "id": "963ec5d4-c617-41fc-8cb7-7b74d9f45195",
    "metadata": {},
    "source": [
-    "# SOMSpeczDegrader Demo\n",
+    "# SOMSpecSelector Demo\n",
     "\n",
     "Author: Sam Schmidt\n",
     "\n",
-    "Last successfully run: December 11, 2024\n",
+    "Last successfully run: Jan 6, 2025\n",
     "\n",
-    "This is a short demo of the use of the SOM-based degrader `SOMSpeczDegrader` that is designed to select a subset of an input galaxy sample via SOM classification such that they match the properties of a reference sample, e.g. to make mock spectroscopic selections for a training set.  \n",
+    "This is a short demo of the use of the SOM-based degrader `SOMSpecSelector` that is designed to select a subset of an input galaxy sample via SOM classification such that they match the properties of a reference sample, e.g. to make mock spectroscopic selections for a training set.  \n",
     "\n",
     "The code works by training a SOM using the (presumably larger) input dataset, then classifying each galaxy from both the input dataset and the reference dataset to find the best SOM cell.  It then loops over all occupied SOM cells, counts the number of reference galaxies in a cell, and selects the same number of input objects in that cell to include in the degraded sample (if there are more objects in the reference sample than are available to pick from in the reference sample, then it simply takes all available objects, which does mean that you can end up with some incompleteness if areas of your parameter space have more objects in the reference sample than the input).  This should naturally force the chosen subsample to match (as much as possible given SOM cell classification given the input parameters) the properties of the reference sample.\n",
     "\n",
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.creation.degraders.specz_som import SOMSpeczDegrader\n",
+    "from rail.creation.degraders.specz_som import SOMSpecSelector\n",
     "from rail.utils.path_utils import find_rail_file\n",
     "from rail.core.data import TableHandle, PqHandle\n",
     "from rail.core.stage import RailStage"
@@ -54,7 +54,7 @@
     "First, let's set up the RAIL DataStore, which is explained in other RAIL demo notebooks, as our interface to the data.  We will read in two files, one for reference (e.g. a specz sample that we would wish to model), and an input dataset.  Because the samples that are included with RAIL are both representative, we will first make a few cuts to mimic incompleteness before adding to the datastore.\n",
     "\n",
     "\n",
-    "**Note:** The SOMSpeczDegrader stage requires a reference/spectroscopic set, and the stage expects that stage to be labeled as \"spec_data\" in the DataStore!  So, once we make a few cuts to our example file, we will specify the name in the datastore as \"spec_data\".  Later in the notebook we will have to set a different name in the `aliases` for a second instance of the stage if we want to use a file with a different label as the reference/specz file (more on that below):"
+    "**Note:** The SOMSpecSelector stage requires a reference/spectroscopic set, and the stage expects that stage to be labeled as \"spec_data\" in the DataStore!  So, once we make a few cuts to our example file, we will specify the name in the datastore as \"spec_data\".  Later in the notebook we will have to set a different name in the `aliases` for a second instance of the stage if we want to use a file with a different label as the reference/specz file (more on that below):"
    ]
   },
   {
@@ -151,7 +151,7 @@
    "id": "e94896ea-978c-48cb-a92b-a2e293b3d3bc",
    "metadata": {},
    "source": [
-    "We can see that, given our cuts, our \"specz\" data is no longer representaive of the input sample.  Now, let's set up our degrader to try to select a subset of galaxies that matches the number and distribution of the specz sample.  We'll start by setting up the `SOMSpeczDegrader` stage.  As input, the stage takes in multiple config parameters, these are:\n",
+    "We can see that, given our cuts, our \"specz\" data is no longer representaive of the input sample.  Now, let's set up our degrader to try to select a subset of galaxies that matches the number and distribution of the specz sample.  We'll start by setting up the `SOMSpecSelector` stage.  As input, the stage takes in multiple config parameters, these are:\n",
     "\n",
     "- noncolor_cols: a list of column names in the files that will be used directly in training the SOM\n",
     "\n",
@@ -166,7 +166,7 @@
     "- som_size: a tuple,  e.g. (32, 32), that specifies the shape of the SOM.  (32, 32) is the default.\n",
     "\n",
     "\n",
-    "Let's set up our inputs.  As an example, let's train our SOM using i-band magnitude, redshift, and the colors u-g, g-r, r-i, i-z, and z-y.  To do this, we will specify `noncolor_cols` of 'mag_i_lsst' and 'redshift', and color_cols with all six magnitudes.  The code will difference the six magnitudes, producing the desired five colors.  Thus, our SOM inputs will be trained on seven inputs: `mag_i_lsst`, `redshift`, `u-g`, `g-r`, `r-i`, `i-z`, and `z-y`.  Note that we have explicitly included redshift.  This is possible because both our specz sample and our simulated input sample have true redshift available.  In real datasets where specz is not available, we would not be able to include redshift, and results will likely not match as well, particularly for the redshift distribution.\n",
+    "Let's set up our inputs.  As an example, let's train our SOM using i-band magnitude, redshift, and the colors u-g, g-r, r-i, i-z, and z-y.  To do this, we will specify `noncolor_cols` of 'mag_i_lsst' and 'redshift', and color_cols with all six magnitudes.  The code will difference the six magnitudes, producing the desired five colors.  Thus, our SOM inputs will be trained on six inputs: `mag_i_lsst`, `u-g`, `g-r`, `r-i`, `i-z`, and `z-y`.  Given that our mock data has true redshifts, we could also include `redshift` as an explicit feature, which would lead to even better results; however, for this demo we will test without redshift included as a test of how well the method does in recovering the redshift distribution with only the implicit color -> redshift relation information included.\n",
     "\n",
     "We also need to specify the magnitude and color limits, we'll use the 1 sigma i-band 10 year limit for i-band and just put -1.0 for redshift.  For colors we'll just put 0.0 for all colors."
    ]
@@ -179,7 +179,7 @@
    "outputs": [],
    "source": [
     "bands = ['u', 'g', 'r', 'i', 'z', 'y']\n",
-    "noncol_cols = ['mag_i_lsst', 'redshift']\n",
+    "noncol_cols = ['mag_i_lsst']\n",
     "col_cols = []\n",
     "for band in bands:\n",
     "    col_cols.append(f\"mag_{band}_lsst\")\n",
@@ -201,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "som_degrade = SOMSpeczDegrader.make_stage(name=\"som_degrader\", output=\"specz_mock_sample.pq\", **som_dict)"
+    "som_degrade = SOMSpecSelector.make_stage(name=\"som_degrader\", output=\"specz_mock_sample.pq\", **som_dict)"
    ]
   },
   {
@@ -234,7 +234,7 @@
     "magbins = np.linspace(14, 25.5, 52)\n",
     "axs[0].hist(test_data()['redshift'], bins=xbins, alpha=0.15, color='orange', label='input sample');\n",
     "axs[0].hist(ref_data()['redshift'], bins=xbins, alpha=0.5, color='k', label='specz sample');\n",
-    "axs[0].hist(trimdf()['redshift'], bins=xbins, alpha=0.15, color='r', label='degraded sample')\n",
+    "axs[0].hist(trimdf()['redshift'], bins=xbins, alpha=0.15, color='b', label='degraded sample')\n",
     "axs[0].set_xlabel('redshift', fontsize=14)\n",
     "axs[0].legend(loc='upper right', fontsize=12)\n",
     "axs[0].set_ylabel('number', fontsize=14);\n",
@@ -244,7 +244,7 @@
     "axs[1].scatter(ref_data()['mag_i_lsst'], ref_data()['mag_g_lsst'] - ref_data()['mag_r_lsst'], \n",
     "            s=4, label='specz data', alpha=0.4, color='k')\n",
     "axs[1].scatter(trimdf()['mag_i_lsst'], trimdf()['mag_g_lsst'] - trimdf()['mag_r_lsst'], \n",
-    "            s=4, label='degraded data', alpha=0.4, color='r')\n",
+    "            s=4, label='degraded data', alpha=0.4, color='b')\n",
     "axs[1].legend(loc='upper left', fontsize=12)\n",
     "axs[1].set_ylim(-1,3.5);\n",
     "axs[1].set_xlabel(\"i-band mag\", fontsize=14)\n",
@@ -258,14 +258,14 @@
     "            s=4, label='specz data', alpha=0.4, color='k')\n",
     "axs[2].scatter(trimdf()['mag_g_lsst'] - trimdf()['mag_r_lsst'],\n",
     "               trimdf()['mag_r_lsst'] - trimdf()['mag_i_lsst'], \n",
-    "            s=4, label='degraded data', alpha=0.3, color='r')\n",
+    "            s=4, label='degraded data', alpha=0.3, color='b')\n",
     "axs[2].legend(loc='upper right', fontsize=12)\n",
     "axs[2].set_xlabel(\"g - r\", fontsize=14)\n",
     "axs[2].set_ylabel(\"r - i\", fontsize=14)\n",
     "\n",
     "axs[3].hist(test_data()['mag_i_lsst'], bins=magbins, alpha=0.15, color='orange', label='input sample');\n",
     "axs[3].hist(ref_data()['mag_i_lsst'], bins=magbins, alpha=0.5, color='k', label='specz sample');\n",
-    "axs[3].hist(trimdf()['mag_i_lsst'], bins=magbins, alpha=0.15, color='r', label='degraded sample')\n",
+    "axs[3].hist(trimdf()['mag_i_lsst'], bins=magbins, alpha=0.15, color='b', label='degraded sample')\n",
     "axs[3].set_xlabel('i-band magnitude', fontsize=14)\n",
     "axs[3].legend(loc='upper left', fontsize=12)\n",
     "axs[3].set_ylabel('number', fontsize=14);\n"
@@ -281,6 +281,14 @@
     "\n",
     "**Note:**\n",
     "The files are rather large, so you will need to uncomment the lines below in order to download the files and have the second half of this notebook run.  Let's grab some data from the Roman-DESC sims, we'll grab a tar file with two files, one with 37,500 galaxies, and one with 75,000 galaxies:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a49b9217-35db-4100-8b48-6416ebf9be98",
+   "metadata": {},
+   "source": [
+    "## Uncomment the lines in the cell below and execute to download the data needed for the rest of the notebook!"
    ]
   },
   {
@@ -355,7 +363,7 @@
    "id": "706609b1-8295-4521-af0a-60fa4a2d60d6",
    "metadata": {},
    "source": [
-    "As in the first example, we will just use i, redshift, and the five colors to build the SOM.  Because the colors are already present we can just add them directly to the non-color columns. Let's set things up appropriately:"
+    "As in the first example, we will just use one magnitude, `i`, and the five colors to build the SOM.  Because the colors are already present we can just add them directly to the non-color columns. Let's set things up appropriately:"
    ]
   },
   {
@@ -365,7 +373,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "noncol_cols = ['i', 'redshift', 'ug', 'gr', 'ri', 'iz', 'zy']\n",
+    "noncol_cols = ['i', 'ug', 'gr', 'ri', 'iz', 'zy']\n",
     "col_cols = []\n",
     "\n",
     "noncol_nondet = [28.62, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n",
@@ -383,7 +391,7 @@
    "id": "8ca62808-f505-4a3e-a9f2-640ad31ac5db",
    "metadata": {},
    "source": [
-    "**Note:** as mentioned earlier in this demo, the `SOMSpeczDegrader` stage expects the reference/spectroscopic data file to be labeled as \"spec_data\" in the DataStore.  As we already loaded the previous example data with that name, we'll need to tell this second copy of the `SOMSpeczDegrader` stage that we will be using a dataset with a different label.  We do this by setting the new label in a dictionary fed in as `aliases` to the stage.  We added the new reference/specz file with the label \"big_spec\", so we can simply add `aliases=dict(spec_data=\"big_spec\")` to let the stage know which file to use as the reference/spec data."
+    "**Note:** as mentioned earlier in this demo, the `SOMSpecSelector` stage expects the reference/spectroscopic data file to be labeled as \"spec_data\" in the DataStore.  As we already loaded the previous example data with that name, we'll need to tell this second copy of the `SOMSpecSelector` stage that we will be using a dataset with a different label.  We do this by setting the new label in a dictionary fed in as `aliases` to the stage.  We added the new reference/specz file with the label \"big_spec\", so we can simply add `aliases=dict(spec_data=\"big_spec\")` to let the stage know which file to use as the reference/spec data."
    ]
   },
   {
@@ -394,10 +402,10 @@
    "outputs": [],
    "source": [
     "# note that \n",
-    "roman_som_degrade = SOMSpeczDegrader.make_stage(name=\"roman_som_degrader\", \n",
-    "                                                output=\"roman_specz_mock_sample.pq\", \n",
-    "                                                aliases = dict(spec_data=\"big_spec\"),\n",
-    "                                                **som_dict)"
+    "roman_som_degrade = SOMSpecSelector.make_stage(name=\"roman_som_degrader\", \n",
+    "                                               output=\"roman_specz_mock_sample.pq\", \n",
+    "                                               aliases = dict(spec_data=\"big_spec\"),\n",
+    "                                               **som_dict)"
    ]
   },
   {
@@ -430,7 +438,7 @@
     "magbins = np.linspace(14, 25.5, 52)\n",
     "axs[0].hist(big_test_data()['redshift'], bins=xbins, alpha=0.15, color='orange', label='input sample');\n",
     "axs[0].hist(big_spec_data()['redshift'], bins=xbins, alpha=0.5, color='k', label='specz sample');\n",
-    "axs[0].hist(roman_trim()['redshift'], bins=xbins, alpha=0.15, color='r', label='degraded sample')\n",
+    "axs[0].hist(roman_trim()['redshift'], bins=xbins, alpha=0.15, color='b', label='degraded sample')\n",
     "axs[0].set_xlabel('redshift', fontsize=14)\n",
     "axs[0].legend(loc='upper right', fontsize=12)\n",
     "axs[0].set_ylabel('number', fontsize=14);\n",
@@ -440,7 +448,7 @@
     "axs[1].scatter(big_spec_data()['i'], big_spec_data()['gr'], \n",
     "            s=4, label='specz data', alpha=0.4, color='k')\n",
     "axs[1].scatter(roman_trim()['i'], roman_trim()['gr'], \n",
-    "            s=4, label='degraded data', alpha=0.4, color='r')\n",
+    "            s=4, label='degraded data', alpha=0.4, color='b')\n",
     "axs[1].legend(loc='upper left', fontsize=12)\n",
     "axs[1].set_ylim(-.5,2.2);\n",
     "\n",
@@ -452,14 +460,14 @@
     "               s=4, label='specz data', alpha=0.4, color='k')\n",
     "axs[2].scatter(roman_trim()['gr'],\n",
     "               roman_trim()['ri'],\n",
-    "               s=4, label='degraded data', alpha=0.3, color='r')\n",
+    "               s=4, label='degraded data', alpha=0.3, color='b')\n",
     "axs[2].legend(loc='upper right', fontsize=12)\n",
     "axs[2].set_xlabel(\"g - r\", fontsize=14)\n",
     "axs[2].set_ylabel(\"r - i\", fontsize=14)\n",
     "\n",
     "axs[3].hist(big_test_data()['i'], bins=magbins, alpha=0.15, color='orange', label='input sample');\n",
     "axs[3].hist(big_spec_data()['i'], bins=magbins, alpha=0.5, color='k', label='specz sample');\n",
-    "axs[3].hist(roman_trim()['i'], bins=magbins, alpha=0.15, color='r', label='degraded sample')\n",
+    "axs[3].hist(roman_trim()['i'], bins=magbins, alpha=0.15, color='b', label='degraded sample')\n",
     "axs[3].set_xlabel('i-band magnitude', fontsize=14)\n",
     "axs[3].legend(loc='upper left', fontsize=12)\n",
     "axs[3].set_ylabel('number', fontsize=14);"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
+    "pandas",
     "pz-rail-base>=1.0.3",
     "scikit-learn",
     "minisom",

--- a/src/rail/creation/degraders/specz_som.py
+++ b/src/rail/creation/degraders/specz_som.py
@@ -19,7 +19,7 @@ default_color_cols = ['u', 'g', 'r', 'i', 'z', 'y']
 default_colorcol_nondet = [27.79, 29.04, 29.06, 28.62, 27.98, 27.05]
 
 
-class SOMSpeczDegrader(Selector):
+class SOMSpecSelector(Selector):
     """Class that creates a specz sample by training a SOM on data with spec-z,
     classifying all galaxies from a larger sample via the SOM, then selecting
     the same number of galaxies in each SOM cell as there are in the specz
@@ -45,7 +45,7 @@ class SOMSpeczDegrader(Selector):
     final dataset that mimics the input reference sample.
     """
 
-    name = "SOMSpeczDegrader"
+    name = "SOMSpecSelector"
     config_options = Selector.config_options.copy()
     config_options.update(nondetect_val=SHARED_PARAMS,
                           noncolor_cols=Param(list, default_noncolor_cols, msg="data columns used for SOM, can be a single band if"
@@ -89,7 +89,6 @@ class SOMSpeczDegrader(Selector):
         check_vals = self.config.noncolor_cols + self.config.color_cols
         check_lims = self.config.noncolor_nondet + self.config.color_nondet
         for data in (spec_data, deep_data):
-            print("doing checks")
             for val, lim in zip(check_vals, check_lims):
                 if val not in data.keys():  # pragma: no cover
                     raise KeyError(f"required key {val} not present in input data file!")

--- a/tests/som/test_som_speczdegrader.py
+++ b/tests/som/test_som_speczdegrader.py
@@ -4,9 +4,9 @@ import pandas as pd
 import pytest
 from rail.core.stage import RailStage
 from rail.core.data import DATA_STORE, PqHandle
-from rail.creation.degraders.specz_som import SOMSpeczDegrader
+from rail.creation.degraders.specz_som import SOMSpecSelector
 
-def test_SOMSpeczDegrader():
+def test_SOMSpecSelector():
     """test of the specz subset degrader"""
     nspec = 1000
     ninput = 10000
@@ -44,9 +44,9 @@ def test_SOMSpeczDegrader():
                     noncolor_nondet=noncol_nondet,
                     color_nondet=col_nondet)
 
-    som_degrade = SOMSpeczDegrader.make_stage(name="roman_som_degrader", 
-                                              output="test_degraded_som.pq", 
-                                              **som_dict)
+    som_degrade = SOMSpecSelector.make_stage(name="roman_som_degrader", 
+                                             output="test_degraded_som.pq", 
+                                             **som_dict)
     cutdf = som_degrade(input_data)
     for col in columns:
         assert col in cutdf().keys()


### PR DESCRIPTION
Addresses #19 by changing the name of SOMSpeczDegrader to SOMSpecSelector to be more consistent with the other Selector stage names.  I also removed `redshift` from the set of features used in the example notebook, as the results look just as good without including it.  I also swapped the color of one of the plot elements because red vs orange seemed a bit bad for color scheme.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
