### PR TITLE
update config parameter types addresses #22

### DIFF
--- a/src/rail/creation/degraders/specz_som.py
+++ b/src/rail/creation/degraders/specz_som.py
@@ -54,7 +54,7 @@ class SOMSpecSelector(Selector):
                           color_cols=Param(list, default_color_cols, msg="columns that will be differenced to make"
                                            " colors.  This will be done in order, so put in increasing WL order"),
                           color_nondet=Param(list, default_colorcol_nondet, msg="list of nondetect replacement vals for color columns"),
-                          som_size=Param(tuple, (32, 32), msg="tuple containing the size (x, y) of the SOM"),
+                          som_size=Param(list, [32, 32], msg="tuple containing the size (x, y) of the SOM"),
                           n_epochs=Param(int, 10, msg="number of training epochs."))
 
     inputs = [('spec_data', TableHandle),

--- a/src/rail/estimation/algos/somoclu_som.py
+++ b/src/rail/estimation/algos/somoclu_som.py
@@ -301,7 +301,7 @@ class SOMocluSummarizer(SZPZSummarizer):
                           spec_weightcol=Param(str, "", msg="name of specz weight col, if present"),
                           split=Param(int, 200, msg="the size of data chunks when calculating the distances between the codebook and data"),
                           nsamples=Param(int, 20, msg="number of bootstrap samples to generate"),
-                          useful_clusters=Param(np.ndarray, np.array([]), msg="the cluster indices that are used for calibration. If not given, then "
+                          useful_clusters=Param(list, [], msg="the cluster indices that are used for calibration. If not given, then "
                                                +"all the clusters containing spec sample are used."),)
     outputs = [('output', QPHandle),
                ('single_NZ', QPHandle),
@@ -516,15 +516,15 @@ class SOMocluSummarizer(SZPZSummarizer):
         print(uncovered_clusters)
         
         covered_clusters = phot_cluster_set - uncovered_clusters
-        if self.config.useful_clusters.size == 0:
+        if len(self.config.useful_clusters) == 0:
             self.useful_clusters = covered_clusters
         else:  # pragma: no cover        
             if set(self.config.useful_clusters) <= covered_clusters:
-                self.useful_clusters = self.config.useful_clusters
+                self.useful_clusters = np.array(self.config.useful_clusters)
             else:
                 print("Warning: input useful clusters is not a subset of spec-covered clusters."
                      +"Taking the intersection.")                
-                self.useful_clusters = np.intersect1d(self.config.useful_clusters, np.asarray(list(covered_clusters)))
+                self.useful_clusters = np.intersect1d(np.array(self.config.useful_clusters), np.asarray(list(covered_clusters)))
                 if self.useful_clusters.size == 0:  # pragma: no cover
                     raise ValueError("Input useful clusters have no intersection with spec-covered clusters!")
         


### PR DESCRIPTION
Update the types for som_size in SOMSpecSelector and useful_clusters in somoclu.  This is to address #22 warnings due to tuples and np.ndarrays not working well with yaml outputs.  All tests pass locally.  We may need to update the somoclu notebook in the main RAIL repo to switch to lists rather than ndarrays in the demo there.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
